### PR TITLE
Update incorrect documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/opened-partnerapi.
+Bug reports and pull requests are welcome on GitHub at  https://github.com/openedinc/opened-partnerapi/issues.
 
 
 ## License


### PR DESCRIPTION
The current "contributing" shows a URL that leads to a 404
